### PR TITLE
Support env-based config overrides and .env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ section.
 > 
 > These can be changed by editing the config file.
 
+## Environment Variable Overrides
+You can override sensitive values from `config/config.yml` without editing the file by setting environment variables before starting ProxyWeb.
+
+- Web UI credentials:
+  - `PROXYWEB_ADMIN_USER` – overrides `auth.admin_user`
+  - `PROXYWEB_ADMIN_PASSWORD` – overrides `auth.admin_password`
+- ProxySQL server DSN values (per server, using the server key from the config):
+  - `PROXYWEB_SERVER_<SERVERNAME>_USER`
+  - `PROXYWEB_SERVER_<SERVERNAME>_PASSWORD`
+  - `PROXYWEB_SERVER_<SERVERNAME>_HOST`
+  - `PROXYWEB_SERVER_<SERVERNAME>_PORT`
+  - `PROXYWEB_SERVER_<SERVERNAME>_DATABASE`
+
+For example, to override the credentials for the default `proxysql` server:
+```
+export PROXYWEB_SERVER_PROXYSQL_USER=myuser
+export PROXYWEB_SERVER_PROXYSQL_PASSWORD=mypassword
+```
+
+Multiple `dsn` entries share the same overrides for the specified server key.
+
 
 ---
 

--- a/mdb.py
+++ b/mdb.py
@@ -23,6 +23,7 @@ import logging
 import yaml
 import subprocess
 from datetime import datetime
+import os
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -35,9 +36,61 @@ def get_config(config="config/config.yml"):
     try:
         with open(config, 'r') as yml:
             cfg = yaml.safe_load(yml)
+        cfg = _apply_env_overrides(cfg)
         return cfg
     except Exception as e:
-        raise ValueError("Error opening or parsing the file: %" % config)
+        raise ValueError("Error opening or parsing the file: %s" % config)
+
+
+def _apply_env_overrides(cfg):
+    """
+    Override values from config.yml with environment variables when provided.
+    """
+    if not cfg:
+        return cfg
+
+    # Override admin UI credentials
+    admin_user = os.getenv("PROXYWEB_ADMIN_USER")
+    admin_password = os.getenv("PROXYWEB_ADMIN_PASSWORD")
+    if admin_user or admin_password:
+        cfg.setdefault('auth', {})
+        if admin_user:
+            logging.debug("Overriding admin user from environment variable.")
+            cfg['auth']['admin_user'] = admin_user
+        if admin_password:
+            logging.debug("Overriding admin password from environment variable.")
+            cfg['auth']['admin_password'] = admin_password
+
+    # Override per-server DSN credentials and connection parameters
+    for server_name, server_content in cfg.get('servers', {}).items():
+        prefix = f"PROXYWEB_SERVER_{server_name.upper()}"
+        user = os.getenv(f"{prefix}_USER")
+        password = os.getenv(f"{prefix}_PASSWORD")
+        host = os.getenv(f"{prefix}_HOST")
+        port = os.getenv(f"{prefix}_PORT")
+        database = os.getenv(f"{prefix}_DATABASE")
+
+        if not any([user, password, host, port, database]):
+            continue
+
+        for dsn in server_content.get('dsn', []):
+            if user:
+                logging.debug("Overriding user for server %s from environment variable.", server_name)
+                dsn['user'] = user
+            if password:
+                logging.debug("Overriding password for server %s from environment variable.", server_name)
+                dsn['passwd'] = password
+            if host:
+                logging.debug("Overriding host for server %s from environment variable.", server_name)
+                dsn['host'] = host
+            if port:
+                logging.debug("Overriding port for server %s from environment variable.", server_name)
+                dsn['port'] = port
+            if database:
+                logging.debug("Overriding database for server %s from environment variable.", server_name)
+                dsn['db'] = database
+
+    return cfg
 
 
 def db_connect(db, server, autocommit=False, buffered=False, dictionary=True):

--- a/misc/entry.sh
+++ b/misc/entry.sh
@@ -4,6 +4,19 @@ GUNICORN_PORT=5000
 GUNICORN_WORKERS=2
 GUNICORN_THREADS=2
 
+# Load environment variables from .env file if present
+ENV_FILE="/app/.env"
+if [ -n "${PROXYWEB_ENV_FILE}" ]; then
+    ENV_FILE="${PROXYWEB_ENV_FILE}"
+fi
+
+if [ -f "${ENV_FILE}" ]; then
+    echo "Loading environment variables from ${ENV_FILE}"
+    set -a
+    . "${ENV_FILE}"
+    set +a
+fi
+
 #Generate a unique secret key for flask
 SECRET_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
 sed -i "s/12345678901234567890/${SECRET_KEY}/" ${CONFIG}


### PR DESCRIPTION
- allow overriding admin credentials and per-server DSN fields from PROXYWEB_* env vars during config load
- load environment variables from a .env file (or PROXYWEB_ENV_FILE) before starting Gunicorn in entry.sh