### PR TITLE
fix: handle ProxySQL 3.x admin rejecting SET @@session.autocommit

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -566,11 +566,14 @@ def db_connect(db, server, autocommit=False, buffered=False, dictionary=True):
 
         try:
             db['cnf']['servers'][server]['conn'].autocommit = autocommit
-        except mysql.connector.Error:
-            # ProxySQL 3.x admin interface does not support
-            # SET @@session.autocommit, which mysql-connector-python
-            # sends internally when setting the autocommit property.
-            pass
+        except mysql.connector.Error as err:
+            if "autocommit" in str(err).lower():
+                # ProxySQL 3.x admin interface does not support
+                # SET @@session.autocommit, which mysql-connector-python
+                # sends internally when setting the autocommit property.
+                logging.warning("Server %s does not support SET @@session.autocommit, skipping: %s", server, err)
+            else:
+                raise
         db['cnf']['servers'][server]['conn'].get_warnings = True
 
         db['cnf']['servers'][server]['cur'] = db['cnf']['servers'][server]['conn'].cursor(buffered=buffered,

--- a/mdb.py
+++ b/mdb.py
@@ -564,8 +564,14 @@ def db_connect(db, server, autocommit=False, buffered=False, dictionary=True):
                 config['user'],
                 config['db']))
 
-        db['cnf']['servers'][server]['conn'] .autocommit = autocommit
-        db['cnf']['servers'][server]['conn'] .get_warnings = True
+        try:
+            db['cnf']['servers'][server]['conn'].autocommit = autocommit
+        except mysql.connector.Error:
+            # ProxySQL 3.x admin interface does not support
+            # SET @@session.autocommit, which mysql-connector-python
+            # sends internally when setting the autocommit property.
+            pass
+        db['cnf']['servers'][server]['conn'].get_warnings = True
 
         db['cnf']['servers'][server]['cur'] = db['cnf']['servers'][server]['conn'].cursor(buffered=buffered,
                                                                                             dictionary=dictionary)

--- a/mdb.py
+++ b/mdb.py
@@ -567,7 +567,8 @@ def db_connect(db, server, autocommit=False, buffered=False, dictionary=True):
         try:
             db['cnf']['servers'][server]['conn'].autocommit = autocommit
         except mysql.connector.Error as err:
-            if "autocommit" in str(err).lower():
+            msg = str(err).lower()
+            if "unknown global variable" in msg and "@@session.autocommit" in msg:
                 # ProxySQL 3.x admin interface does not support
                 # SET @@session.autocommit, which mysql-connector-python
                 # sends internally when setting the autocommit property.


### PR DESCRIPTION
## Summary

`mysql-connector-python` sends `SET @@session.autocommit = ON/OFF` internally when the `.autocommit` property is set on a connection object. ProxySQL 3.x admin interface does not recognize this session variable and returns:

```
1045 (28000): ProxySQL Admin Error: ERROR: Unknown global variable: '@@session.autocommit'.
```

This causes `db_connect()` to raise a `ValueError`, making proxyweb unable to connect to ProxySQL 3.x instances.

## Fix

Wrap the `autocommit` property setter in `db_connect()` with a `try/except mysql.connector.Error` block so the connection proceeds even when the admin interface rejects the statement.

## Environment

- ProxySQL 3.0.6
- mysql-connector-python (bundled in proxyweb Docker image, Python 3.14)
- proxyweb/proxyweb:latest

## Test

Verified manually against two ProxySQL 3.0.6 instances. Dashboard loads successfully after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection resilience: if the server rejects applying session autocommit, the app now logs a clear warning and continues connecting instead of failing. Other connection errors are still surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->