### PR TITLE
feat: server-side pagination for large tables to prevent OOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ The `SECRET_KEY` placeholder `12345678901234567890` is replaced at container sta
 
 1. All routes require `@login_required` (session-based, credentials from config).
 2. `render_list_dbs` (route `/`) sets up the session with `dblist`, `server`, `servers`, and `misc` — these are reused by templates.
-3. `render_show_table_content` (route `/<server>/<database>/<table>/`) fetches table data via `mdb.get_table_content()` and calls `mdb.process_table_content()` for any table-specific post-processing.
+3. `render_show_table_content` (route `/<server>/<database>/<table>/`) fetches table metadata (column names, row count) via `mdb.get_table_metadata()`. Row data is loaded on demand via `/api/table_data` using DataTables server-side processing — only one page of rows is ever in memory at a time.
 4. Inline row edits/inserts/deletes go to `/api/update_row`, `/api/insert_row`, `/api/delete_row` — these call the corresponding `mdb.*_row()` functions which build and execute SQL against ProxySQL. All three check `mdb.get_read_only(server)` and reject `runtime_*` tables with 403 before mutating.
 5. The SQL form in `show_table_info.html` posts to `/<server>/<database>/<table>/sql/` — SELECT statements render `show_adhoc_report.html`, everything else executes as a change and refreshes the table.
 6. `/api/execute_proxysql_command` only accepts `LOAD`, `SAVE`, and `SELECT CONFIG` statements (validated per-statement after splitting on `;`).
@@ -180,7 +180,7 @@ Rules:
 | hardcoded `'proxysql'` fallback in `render_list_dbs` and `execute_proxysql_command` crashes when first server is not named `proxysql` | `TestDefaultServerFallback` |
 | `dict_to_yaml()` rendered DSN list entries as inline JSON (`{"host": ...}`) instead of block YAML; new server with empty name silently dropped | `TestSettingsUIServer` |
 | `digest_text` in `stats_mysql_query_digest` had leading whitespace, used `pre-wrap`, truncated at 60 chars, and showed raw Unicode arrows instead of FA chevrons | `TestDigestTextDisplay` |
-| `stats_mysql_query_digest` must serve > 100 rows so DataTables activates client-side pagination; pagination HTML is JS-rendered so the test counts `<tr>` in `<tbody>` | `TestZPagination` |
+| `stats_mysql_query_digest` with large row counts caused OOM; server-side pagination loads only one page at a time via `/api/table_data` | `TestZPagination`, `TestServerSidePagination` |
 | readonly user must not modify data, access settings, execute LOAD/SAVE, or run non-SELECT SQL; can browse tables, view config diff, use SQL editor for SELECTs | `TestReadOnlyUser` |
 | login page should show default credentials hint when passwords are at defaults; hint disappears after changing passwords | `TestDefaultCredentialsHint` |
 | `render_list_dbs` crashes with ValueError when `servers:` is empty; admin should be redirected to settings, readonly gets error page | `TestNoServersRedirect` |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ProxyWeb gives you full control over ProxySQL through a clean web interface — 
 
 - **MySQL + PostgreSQL** — manage both MySQL and PostgreSQL backends via ProxySQL 3.x
 - **Multi-server management** — switch between ProxySQL instances from the nav bar
-- **Table browser** — view, search, sort, and paginate any ProxySQL table
+- **Table browser** — view, search, sort, and paginate any ProxySQL table with server-side pagination
 - **Inline editing** — insert, update, and delete rows directly in the browser
 - **SQL query editor** — run ad-hoc queries with quick-query shortcuts for common operations
 - **Query history** — persistent per-server history with dropdown recall and full history page

--- a/app.py
+++ b/app.py
@@ -289,14 +289,14 @@ def render_change(server, database, table):
         select = re.search(r'^\s*SELECT\b.*\bFROM\b', session['sql'], re.I | re.S)
         if not select and session.get('role') == 'readonly':
             error = "Read-only user cannot execute non-SELECT statements"
-            content = mdb.get_table_content(db, server, database, table)
+            content = mdb.get_table_metadata(db, server, database, table)
             return render_template("show_table_info.html", content=content, error=error, message="")
         if select:
             content = mdb.execute_adhoc_query(db, server, session['sql'])
             content['order'] = 'true'
         else:
             ret = mdb.execute_change(db, server, session['sql'])
-            content = mdb.get_table_content(db, server, database, table)
+            content = mdb.get_table_metadata(db, server, database, table)
 
         if "ERROR" in ret:
             error = ret
@@ -763,8 +763,11 @@ def api_table_data():
                             'recordsFiltered': 0, 'data': [],
                             'error': 'Missing or invalid server/table parameter'})
 
+        # Use a request-local db container to avoid cursor state mutation
+        # on the module-level db dict between concurrent requests.
+        req_db = defaultdict(lambda: defaultdict(dict))
         result = mdb.get_table_content_paginated(
-            db, server, database, table,
+            req_db, server, database, table,
             start=start, length=length,
             search_value=search_value,
             order_column=order_col, order_dir=order_dir,

--- a/app.py
+++ b/app.py
@@ -259,8 +259,7 @@ def render_show_table_content(server, database="main", table="global_variables")
         session['read_only'] = mdb.get_read_only(server)
         if session.get('role') == 'readonly':
             session['read_only'] = True
-        content = mdb.get_table_content(db, server, database, table)
-        mdb.process_table_content(table,content)
+        content = mdb.get_table_metadata(db, server, database, table)
         return render_template("show_table_info.html", content=content)
     except Exception as e:
         raise ValueError(e)
@@ -743,6 +742,45 @@ def api_get_schema():
 
 
 _ALLOWED_PROXYSQL_CMD = re.compile(r'^\s*(LOAD|SAVE|SELECT\s+CONFIG)\b', re.IGNORECASE)
+
+@app.route('/api/table_data')
+@login_required
+def api_table_data():
+    """Serve paginated table data for DataTables server-side processing."""
+    try:
+        server = request.args.get('server', session.get('server', ''))
+        database = request.args.get('database', 'main')
+        table = request.args.get('table', '')
+        draw = int(request.args.get('draw', 1))
+        start = int(request.args.get('start', 0))
+        length = int(request.args.get('length', 100))
+        search_value = request.args.get('search[value]', '')
+        order_col = int(request.args.get('order[0][column]', 0))
+        order_dir = request.args.get('order[0][dir]', 'asc')
+
+        if not server or not table or server not in mdb.get_servers():
+            return jsonify({'draw': draw, 'recordsTotal': 0,
+                            'recordsFiltered': 0, 'data': [],
+                            'error': 'Missing or invalid server/table parameter'})
+
+        result = mdb.get_table_content_paginated(
+            db, server, database, table,
+            start=start, length=length,
+            search_value=search_value,
+            order_column=order_col, order_dir=order_dir,
+        )
+        result['draw'] = draw
+        return jsonify(result)
+    except Exception as e:
+        logging.exception(f"API error in table_data: {e}")
+        try:
+            safe_draw = int(request.args.get('draw', 1))
+        except (ValueError, TypeError):
+            safe_draw = 1
+        return jsonify({'draw': safe_draw,
+                        'recordsTotal': 0, 'recordsFiltered': 0,
+                        'data': [], 'error': str(e)})
+
 
 @app.route('/api/execute_proxysql_command', methods=['POST'])
 @login_required

--- a/mdb.py
+++ b/mdb.py
@@ -924,20 +924,25 @@ def get_table_metadata(db, server, database, table):
     try:
         db_connect(db, server=server, dictionary=False)
         cur = db['cnf']['servers'][server]['cur']
-        cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
-        column_names = [i[0] for i in cur.description]
-        cur.fetchall()  # consume empty result set before next query
-        cur.execute(f"SELECT COUNT(*) FROM {_quote_ident(database)}.{_quote_ident(table)}")
-        row_count = cur.fetchone()[0]
-        return {
-            'rows': [],
-            'column_names': column_names,
-            'row_count': row_count,
-            'misc': get_config()['misc'],
-            'server_side': True,
-        }
+        try:
+            cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
+            column_names = [i[0] for i in cur.description]
+            cur.fetchall()  # consume empty result set before next query
+            cur.execute(f"SELECT COUNT(*) FROM {_quote_ident(database)}.{_quote_ident(table)}")
+            row_count = cur.fetchone()[0]
+            return {
+                'rows': [],
+                'column_names': column_names,
+                'row_count': row_count,
+                'misc': get_config()['misc'],
+                'server_side': True,
+            }
+        finally:
+            cur.close()
     except (mysql.connector.Error, mysql.connector.Warning) as e:
-        db['cnf']['servers'][server]['conn'].close()
+        conn = db['cnf']['servers'][server].get('conn')
+        if conn:
+            conn.close()
         raise ValueError(e)
 
 
@@ -955,60 +960,64 @@ def get_table_content_paginated(db, server, database, table,
     try:
         db_connect(db, server=server, dictionary=False)
         cur = db['cnf']['servers'][server]['cur']
+        try:
+            # Get column names
+            cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
+            column_names = [i[0] for i in cur.description]
+            cur.fetchall()  # consume empty result set before next query
 
-        # Get column names
-        cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
-        column_names = [i[0] for i in cur.description]
-        cur.fetchall()  # consume empty result set before next query
+            # Clamp order column
+            order_column = max(0, min(int(order_column), len(column_names) - 1))
+            order_col_name = _quote_ident(column_names[order_column])
 
-        # Clamp order column
-        order_column = max(0, min(int(order_column), len(column_names) - 1))
-        order_col_name = _quote_ident(column_names[order_column])
+            qualified_table = f"{_quote_ident(database)}.{_quote_ident(table)}"
 
-        qualified_table = f"{_quote_ident(database)}.{_quote_ident(table)}"
+            # Total count (unfiltered)
+            cur.execute(f"SELECT COUNT(*) FROM {qualified_table}")
+            records_total = cur.fetchone()[0]
 
-        # Total count (unfiltered)
-        cur.execute(f"SELECT COUNT(*) FROM {qualified_table}")
-        records_total = cur.fetchone()[0]
+            # Build WHERE clause for search
+            where_clause = ""
+            if search_value:
+                escaped = search_value.replace("'", "''").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                conditions = []
+                for col in column_names:
+                    conditions.append(f"CAST({_quote_ident(col)} AS CHAR) LIKE '%{escaped}%'")
+                where_clause = "WHERE " + " OR ".join(conditions)
 
-        # Build WHERE clause for search
-        where_clause = ""
-        if search_value:
-            escaped = search_value.replace("'", "''").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            conditions = []
-            for col in column_names:
-                conditions.append(f"CAST({_quote_ident(col)} AS CHAR) LIKE '%{escaped}%'")
-            where_clause = "WHERE " + " OR ".join(conditions)
+            # Filtered count
+            if where_clause:
+                cur.execute(f"SELECT COUNT(*) FROM {qualified_table} {where_clause}")
+                records_filtered = cur.fetchone()[0]
+            else:
+                records_filtered = records_total
 
-        # Filtered count
-        if where_clause:
-            cur.execute(f"SELECT COUNT(*) FROM {qualified_table} {where_clause}")
-            records_filtered = cur.fetchone()[0]
-        else:
-            records_filtered = records_total
+            # Fetch page
+            sql = (f"SELECT * FROM {qualified_table} {where_clause} "
+                   f"ORDER BY {order_col_name} {order_dir} "
+                   f"LIMIT {length} OFFSET {start}")
+            cur.execute(sql)
+            rows = cur.fetchall()
 
-        # Fetch page
-        sql = (f"SELECT * FROM {qualified_table} {where_clause} "
-               f"ORDER BY {order_col_name} {order_dir} "
-               f"LIMIT {length} OFFSET {start}")
-        cur.execute(sql)
-        rows = cur.fetchall()
+            # Process timestamps
+            content = {'rows': rows, 'column_names': column_names}
+            process_table_content(table, content)
 
-        # Process timestamps
-        content = {'rows': rows, 'column_names': column_names}
-        process_table_content(table, content)
+            # Convert tuples to lists for JSON serialisation
+            data = [list(row) for row in content['rows']]
 
-        # Convert tuples to lists for JSON serialisation
-        data = [list(row) for row in content['rows']]
-
-        return {
-            'recordsTotal': int(records_total),
-            'recordsFiltered': int(records_filtered),
-            'data': data,
-            'column_names': column_names,
-        }
+            return {
+                'recordsTotal': int(records_total),
+                'recordsFiltered': int(records_filtered),
+                'data': data,
+                'column_names': column_names,
+            }
+        finally:
+            cur.close()
     except (mysql.connector.Error, mysql.connector.Warning) as e:
-        db['cnf']['servers'][server]['conn'].close()
+        conn = db['cnf']['servers'][server].get('conn')
+        if conn:
+            conn.close()
         raise ValueError(e)
 
 

--- a/mdb.py
+++ b/mdb.py
@@ -918,6 +918,100 @@ def get_table_content(db, server, database, table):
         db['cnf']['servers'][server]['conn'].close()
         raise ValueError(e)
 
+
+def get_table_metadata(db, server, database, table):
+    """Return column names, row count, and misc config without fetching row data."""
+    try:
+        db_connect(db, server=server, dictionary=False)
+        cur = db['cnf']['servers'][server]['cur']
+        cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
+        column_names = [i[0] for i in cur.description]
+        cur.fetchall()  # consume empty result set before next query
+        cur.execute(f"SELECT COUNT(*) FROM {_quote_ident(database)}.{_quote_ident(table)}")
+        row_count = cur.fetchone()[0]
+        return {
+            'rows': [],
+            'column_names': column_names,
+            'row_count': row_count,
+            'misc': get_config()['misc'],
+            'server_side': True,
+        }
+    except (mysql.connector.Error, mysql.connector.Warning) as e:
+        db['cnf']['servers'][server]['conn'].close()
+        raise ValueError(e)
+
+
+def get_table_content_paginated(db, server, database, table,
+                                start=0, length=100,
+                                search_value='',
+                                order_column=0, order_dir='asc'):
+    """Return a page of rows for DataTables server-side processing."""
+    MAX_LENGTH = 1000
+    length = min(max(int(length), 1), MAX_LENGTH)
+    start = max(int(start), 0)
+    if order_dir not in ('asc', 'desc'):
+        order_dir = 'asc'
+
+    try:
+        db_connect(db, server=server, dictionary=False)
+        cur = db['cnf']['servers'][server]['cur']
+
+        # Get column names
+        cur.execute(f"SELECT * FROM {_quote_ident(database)}.{_quote_ident(table)} LIMIT 0")
+        column_names = [i[0] for i in cur.description]
+        cur.fetchall()  # consume empty result set before next query
+
+        # Clamp order column
+        order_column = max(0, min(int(order_column), len(column_names) - 1))
+        order_col_name = _quote_ident(column_names[order_column])
+
+        qualified_table = f"{_quote_ident(database)}.{_quote_ident(table)}"
+
+        # Total count (unfiltered)
+        cur.execute(f"SELECT COUNT(*) FROM {qualified_table}")
+        records_total = cur.fetchone()[0]
+
+        # Build WHERE clause for search
+        where_clause = ""
+        if search_value:
+            escaped = search_value.replace("'", "''").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            conditions = []
+            for col in column_names:
+                conditions.append(f"CAST({_quote_ident(col)} AS CHAR) LIKE '%{escaped}%'")
+            where_clause = "WHERE " + " OR ".join(conditions)
+
+        # Filtered count
+        if where_clause:
+            cur.execute(f"SELECT COUNT(*) FROM {qualified_table} {where_clause}")
+            records_filtered = cur.fetchone()[0]
+        else:
+            records_filtered = records_total
+
+        # Fetch page
+        sql = (f"SELECT * FROM {qualified_table} {where_clause} "
+               f"ORDER BY {order_col_name} {order_dir} "
+               f"LIMIT {length} OFFSET {start}")
+        cur.execute(sql)
+        rows = cur.fetchall()
+
+        # Process timestamps
+        content = {'rows': rows, 'column_names': column_names}
+        process_table_content(table, content)
+
+        # Convert tuples to lists for JSON serialisation
+        data = [list(row) for row in content['rows']]
+
+        return {
+            'recordsTotal': int(records_total),
+            'recordsFiltered': int(records_filtered),
+            'data': data,
+            'column_names': column_names,
+        }
+    except (mysql.connector.Error, mysql.connector.Warning) as e:
+        db['cnf']['servers'][server]['conn'].close()
+        raise ValueError(e)
+
+
 def process_table_content(table, content):
     """
     Processes content rows by converting time-based fields to UTC datetime strings.

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,7 +40,7 @@
         $(document).ready(function () {
             // Initialize DataTables
             if ($('#proxywebtable').length) {
-                $('#proxywebtable').DataTable({
+                var dtConfig = {
                     "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
                     "pageLength": 100,
                     "responsive": false,
@@ -53,12 +53,66 @@
                         "search": "",
                         "searchPlaceholder": "Search...",
                         "lengthMenu": "Show _MENU_ entries"
-                    }{% if content is defined and content['order'] == "true" %},
-                    "order": [[0, "desc"]]{% endif %}
-                });
+                    }
+                };
 
-                // Enable inline editing after DataTable is initialized
-                enableInlineEditing();
+                {% if content is defined and content['order'] == "true" %}
+                dtConfig.order = [[0, "desc"]];
+                {% endif %}
+
+                if (typeof serverSideMode !== 'undefined' && serverSideMode) {
+                    dtConfig.serverSide = true;
+                    dtConfig.processing = true;
+                    dtConfig.ajax = {
+                        url: '/api/table_data',
+                        data: function(d) {
+                            d.server = tableServer;
+                            d.database = tableDatabase;
+                            d.table = tableName;
+                        }
+                    };
+                    dtConfig.lengthMenu = [[25, 50, 100, 500], [25, 50, 100, 500]];
+
+                    // digest_text column: replicate Jinja truncation logic in JS
+                    if (typeof tableColumnNames !== 'undefined') {
+                        var digestIdx = tableColumnNames.indexOf('digest_text');
+                        if (digestIdx !== -1) {
+                            dtConfig.columnDefs = [{
+                                targets: digestIdx,
+                                render: function(data, type, row, meta) {
+                                    if (type !== 'display' || !data) return data;
+                                    var val = String(data).trim();
+                                    if (val.length > 100) {
+                                        var short = $('<span>').text(val.substring(0, 100)).html();
+                                        var full = $('<span>').text(val).html();
+                                        return '<span class="digest-short">' + short + '</span>'
+                                             + '<span class="digest-full" style="display:none;">' + full + '</span>'
+                                             + ' <a href="#" class="digest-toggle badge text-bg-secondary fw-normal ms-1" onclick="toggleDigest(this);return false;">'
+                                             + '<i class="fas fa-chevron-right fa-xs"></i> more</a>';
+                                    }
+                                    return $('<span>').text(val).html();
+                                },
+                                createdCell: function(td) {
+                                    td.style.whiteSpace = 'normal';
+                                    td.style.wordBreak = 'break-word';
+                                    td.style.minWidth = '400px';
+                                    td.style.maxWidth = '700px';
+                                }
+                            }];
+                        }
+                    }
+
+                    dtConfig.drawCallback = function() {
+                        enableInlineEditing();
+                        initializeTooltips();
+                    };
+                }
+
+                $('#proxywebtable').DataTable(dtConfig);
+
+                if (typeof serverSideMode === 'undefined' || !serverSideMode) {
+                    enableInlineEditing();
+                }
 
                 // Initialize tooltips after table is ready
                 initializeTooltips();

--- a/templates/show_table_info.html
+++ b/templates/show_table_info.html
@@ -451,7 +451,7 @@
             </div>
             <div class="stat-item">
                 <i class="fas fa-rows"></i>
-                <span><strong>Rows:</strong> {{ content['rows']|length }}</span>
+                <span><strong>Rows:</strong> {{ content.get('row_count', content['rows']|length) }}</span>
             </div>
         </div>
     </div>
@@ -463,6 +463,14 @@
         </button>
     </div>
 
+    <script>
+        var tableColumnNames = {{ content['column_names'] | tojson }};
+        var serverSideMode = {{ content.get('server_side', False) | tojson }};
+        var tableServer = {{ session['server'] | tojson }};
+        var tableDatabase = {{ session.get('database', 'main') | tojson }};
+        var tableName = {{ session.get('table', '') | tojson }};
+    </script>
+
     <div>
         <table id="proxywebtable" class="table table-hover table-striped mb-0">
             <thead class="sticky-header">
@@ -473,6 +481,7 @@
                 </tr>
             </thead>
             <tbody>
+                {% if not content.get('server_side') %}
                 {% for row in content['rows'] %}
                     <tr>
                         {% for column in row %}
@@ -493,6 +502,7 @@
                         {% endfor %}
                     </tr>
                 {% endfor %}
+                {% endif %}
             </tbody>
         </table>
     </div>

--- a/test/README.md
+++ b/test/README.md
@@ -6,30 +6,31 @@ suite that exercise ProxyWeb against a real ProxySQL + MySQL backend.
 ## Stack layout
 
 ```
-                          ┌──────────────┐     3306    ┌───────────┐
-               admin ──►  │   proxysql   │ ──────────► │   mysql   │
-               (6032)     │  sql (6033)  │             │  testdb   │
-┌─────────────┐           └──────────────┘             └───────────┘
+                           ┌──────────────┐   3306   ┌────────┐  repl  ┌────────┐
+                admin ──►  │  proxysql2   │ ───────► │ mysql2 │ ─────► │ mysql3 │
+                (6032)     │  sql (6033)  │          │ writer │        │ reader │
+┌─────────────┐            └──────────────┘          └────────┘        └────────┘
 │   proxyweb  │
-│  :5000      │           ┌──────────────┐     3306    ┌───────────┐
-               admin ──►  │   proxysql2  │ ──────────► │   mysql2  │
-               (6034)     │  sql (6035)  │             │  testdb2  │
-└─────────────┘           └──────────────┘             └───────────┘
+│  :5000      │            ┌──────────────┐   5432   ┌──────────┐ repl ┌───────────┐
+                admin ──►  │  proxysql3   │ ───────► │ postgres │ ───► │ postgres2 │
+                (6034)     │ pgsql (6090) │          │  pubshr  │      │  subscr   │
+└─────────────┘            └──────────────┘          └──────────┘      └───────────┘
 ```
 
-| Service         | Image                   | Exposed ports              |
-|-----------------|-------------------------|----------------------------|
-| mysql           | mysql:8.0               | (internal only)            |
-| mysql2          | mysql:8.0               | (internal only)            |
-| proxysql        | proxysql/proxysql:2.7.1 | 6032 admin, 6033 SQL       |
-| proxysql2       | proxysql/proxysql:2.7.1 | 6034 admin, 6035 SQL       |
-| proxysql-init   | mysql:8.0 (one-shot)    | —                          |
-| proxysql2-init  | mysql:8.0 (one-shot)    | —                          |
-| proxyweb        | built from `../`        | 5000                       |
+| Service         | Image                     | Exposed ports                |
+|-----------------|---------------------------|------------------------------|
+| mysql2          | mysql:8.0                 | (internal only)              |
+| mysql3          | mysql:8.0                 | (internal only)              |
+| postgres        | postgres:16               | (internal only)              |
+| postgres2       | postgres:16               | (internal only)              |
+| proxysql2       | proxysql/proxysql:3.0.6   | 6032 admin, 6033 MySQL       |
+| proxysql3       | proxysql/proxysql:3.0.6   | 6034 admin, 6090 PostgreSQL  |
+| proxysql2-init  | mysql:8.0 (one-shot)      | —                            |
+| proxysql3-init  | mysql:8.0 (one-shot)      | —                            |
+| proxyweb        | built from `../`          | 5000                         |
 
 ProxyWeb is configured (via `config/config.yml`) to manage both ProxySQL
-instances. Each connects on port 6032 using the `radmin/radmin` credentials
-defined in the respective `proxysql/proxysql.cnf` and `proxysql/proxysql2.cnf`.
+instances as `proxysql_mysql` and `proxysql_postgres`.
 
 `proxysql2` is pre-seeded with two query rules (rule_id 1 and 2) to enable
 cross-server isolation tests.
@@ -107,10 +108,19 @@ PROXYWEB_USER=admin PROXYWEB_PASS=admin42 python3 test_proxyweb.py
 | `TestSettingsEditRecovery` | Settings edit page accessible without prior navigation  |
 | `TestSettingsUIServer` | UI form produces block YAML; empty server name rejected    |
 | `TestDigestTextDisplay`| digest_text truncation, whitespace, and chevron rendering  |
-| `TestZPagination`      | DataTables pagination activates with >100 rows             |
+| `TestZPagination`      | DataTables server-side pagination with >1000 seeded digests |
+| `TestServerSidePagination` | `/api/table_data` input validation, paging, search, sort, error handling |
 | `TestReadOnlyUser`     | Read-only user restrictions on data modification and settings |
 | `TestDefaultCredentialsHint` | Login page shows/hides default credential hint       |
 | `TestNoServersRedirect`| Empty servers config redirects admin to settings; readonly gets error |
+| `TestQueryHistory`     | Per-server query history isolation, dropdown, full page, clear |
+| `TestProxySQL3Autocommit` | ProxySQL 3.x autocommit compatibility                   |
+| `TestPgSQLNavigation`  | PostgreSQL table browsing and navigation                   |
+| `TestPgSQLServers`     | CRUD on `pgsql_servers` via API                            |
+| `TestPgSQLUsers`       | PostgreSQL users table view and API                        |
+| `TestPgSQLLoadSave`    | LOAD/SAVE commands for PostgreSQL ProxySQL instance        |
+| `TestPgSQLQueryViaSQL` | SQL execution against PostgreSQL ProxySQL frontend         |
+| `TestPgSQLReplication` | PostgreSQL logical replication end-to-end                  |
 
 ## Directory structure
 
@@ -126,29 +136,31 @@ test/
 ├── config/
 │   └── config.yml            # proxyweb config: both proxysql + proxysql2
 ├── mysql/
-│   ├── init.sql              # mysql: monitor/proxyuser users + testdb.items seed
-│   └── init2.sql             # mysql2: monitor/proxyuser2 users + testdb2.products seed
+│   ├── init2.sql             # mysql2: monitor/proxyuser2 users + testdb2 seed
+│   └── init3.sql             # mysql3: read-only replica setup
+├── postgres/
+│   ├── init.sql              # postgres: pguser + testdb_pg seed + publication
+│   └── init2.sql             # postgres2: subscription setup
 └── proxysql/
-    ├── proxysql.cnf          # ProxySQL 1 config (targets mysql)
-    ├── proxysql2.cnf         # ProxySQL 2 config (targets mysql2)
-    ├── init.sql              # ProxySQL 1 init: backend + user registration
-    └── init2.sql             # ProxySQL 2 init: backend + user + 2 query rules
+    ├── proxysql2.cnf         # ProxySQL MySQL config (targets mysql2/mysql3)
+    ├── proxysql3.cnf         # ProxySQL PgSQL config (targets postgres/postgres2)
+    ├── init2.sql             # proxysql2 init: backends + user + query rules
+    └── init3.sql             # proxysql3 init: pgsql backends + user
 ```
 
 ## Credentials used inside the stack
 
-| What                              | Username   | Password   |
-|-----------------------------------|------------|------------|
-| ProxyWeb UI (admin)               | admin      | admin42    |
-| ProxyWeb UI (read-only)           | readonly   | readonly42 |
-| ProxySQL 1 admin interface        | radmin     | radmin     |
-| ProxySQL 1 monitor (MySQL)        | monitor    | monitor    |
-| MySQL 1 application user          | proxyuser  | proxypass  |
-| MySQL 1 root                      | root       | rootpass   |
-| ProxySQL 2 admin interface        | radmin     | radmin     |
-| ProxySQL 2 monitor (MySQL)        | monitor    | monitor    |
-| MySQL 2 application user          | proxyuser2 | proxypass2 |
-| MySQL 2 root                      | root       | rootpass   |
+| What                              | Username    | Password    |
+|-----------------------------------|-------------|-------------|
+| ProxyWeb UI (admin)               | admin       | admin42     |
+| ProxyWeb UI (read-only)           | readonly    | readonly42  |
+| ProxySQL MySQL admin (proxysql2)  | radmin      | radmin      |
+| ProxySQL PgSQL admin (proxysql3)  | radmin      | radmin      |
+| MySQL monitor                     | monitor     | monitor     |
+| MySQL 2 application user          | proxyuser2  | proxypass2  |
+| MySQL 2 / MySQL 3 root           | root        | rootpass    |
+| PostgreSQL application user       | pguser      | pgpass      |
+| PostgreSQL root                   | postgres    | pgpass      |
 
 These are test-only credentials. **Do not use this configuration in production.**
 

--- a/test/test_proxyweb.py
+++ b/test/test_proxyweb.py
@@ -148,10 +148,24 @@ class ProxyWebSession:
         resp.raise_for_status()
         return resp
 
+    def get_table_data(self, server, database, table, **params):
+        """Fetch paginated table rows via /api/table_data (server-side DataTables)."""
+        defaults = {
+            "server": server, "database": database, "table": table,
+            "draw": "1", "start": "0", "length": "100",
+            "search[value]": "", "order[0][column]": "0",
+            "order[0][dir]": "asc",
+        }
+        defaults.update(params)
+        resp = self.session.get(f"{BASE_URL}/api/table_data",
+                                params=defaults, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
     def _refresh_csrf(self, html):
         """
         Extracts a CSRF token from the provided HTML and stores it on the instance as `csrf_token`.
-        
+
         Parameters:
             html (str): HTML content to search for a `<meta name="csrf-token" content="...">` tag. If a matching meta tag is found, its `content` value is assigned to `self.csrf_token`; otherwise `self.csrf_token` is left unchanged.
         """
@@ -1024,13 +1038,17 @@ class TestMultiServer(unittest.TestCase):
 
     def test_mysql_server_has_mysql_backends(self):
         """proxysql_mysql should list mysql2 as its backend."""
-        resp = self.s.get(f"/{self.S1}/{self.DB}/mysql_servers/")
-        self.assertIn("mysql2", resp.text)
+        self.s.get(f"/{self.S1}/{self.DB}/mysql_servers/")
+        data = self.s.get_table_data(self.S1, self.DB, "mysql_servers")
+        flat = str(data["data"])
+        self.assertIn("mysql2", flat)
 
     def test_pg_server_has_postgres_backends(self):
         """proxysql_postgres should list postgres backends."""
-        resp = self.s.get(f"/{self.S2}/{self.DB}/pgsql_servers/")
-        self.assertIn("postgres", resp.text)
+        self.s.get(f"/{self.S2}/{self.DB}/pgsql_servers/")
+        data = self.s.get_table_data(self.S2, self.DB, "pgsql_servers")
+        flat = str(data["data"])
+        self.assertIn("postgres", flat)
 
     # ------------------------------------------------------------------
     # Query rules: proxysql_mysql pre-seeded with 2 rules
@@ -1041,8 +1059,10 @@ class TestMultiServer(unittest.TestCase):
         resp = self.s.get(f"/{self.S1}/{self.DB}/mysql_query_rules/")
         self.assertEqual(resp.status_code, 200)
         self.assertIn("rule_id", resp.text)
-        self.assertIn(">1<", resp.text)
-        self.assertIn(">2<", resp.text)
+        data = self.s.get_table_data(self.S1, self.DB, "mysql_query_rules")
+        rule_ids = [str(row[0]) for row in data["data"]]
+        self.assertIn("1", rule_ids)
+        self.assertIn("2", rule_ids)
 
     # ------------------------------------------------------------------
     # Config diff works independently per server
@@ -1479,61 +1499,52 @@ class TestDigestTextDisplay(unittest.TestCase):
         resp = self._page()
         self.assertEqual(resp.status_code, 200)
 
-    def test_truncation_elements_present(self):
-        """Long digest_text rows must render digest-short, digest-full, and digest-toggle."""
+    def test_truncation_js_render_present(self):
+        """Page JS must contain the digest-short/digest-full/digest-toggle render logic."""
         resp = self._page()
         html = resp.text
-        self.assertIn('class="digest-short"', html,
-                      "digest-short span missing — long digest_text rows need truncation markup")
-        self.assertIn('class="digest-full"', html,
-                      "digest-full span missing — long digest_text rows need expand markup")
+        self.assertIn('digest-short', html,
+                      "digest-short class missing from JS render function")
+        self.assertIn('digest-full', html,
+                      "digest-full class missing from JS render function")
         self.assertIn('digest-toggle', html,
-                      "digest-toggle link missing — long digest_text rows need a toggle")
+                      "digest-toggle class missing from JS render function")
 
     def test_toggle_uses_fa_chevron_not_unicode_arrow(self):
-        """Toggle badge must use Font Awesome chevron, not raw Unicode arrow characters."""
+        """JS render function must use Font Awesome chevron, not raw Unicode arrow characters."""
         resp = self._page()
         html = resp.text
         self.assertIn('fa-chevron-right', html,
-                      "fa-chevron-right icon missing from digest toggle badge")
+                      "fa-chevron-right icon missing from digest toggle JS render")
         self.assertNotIn('&#9654;', html,
                          "Raw Unicode arrow &#9654; (▶) must not appear in digest toggle")
         self.assertNotIn('\u25ba', html,
                          "Raw Unicode arrow ▶ must not appear in digest toggle")
 
-    def test_no_leading_whitespace_in_short_span(self):
-        """digest-short span content must not start with whitespace (|trim must be applied)."""
-        resp = self._page()
-        # Match a digest-short span whose content begins with whitespace
-        bad = re.search(r'<span class="digest-short">\s+\S', resp.text)
-        self.assertIsNone(bad,
-                          "digest-short span has leading whitespace — |trim not applied in template")
-
-    def test_td_uses_white_space_normal_not_pre_wrap(self):
-        """digest_text <td> must use white-space:normal so newlines are not preserved."""
+    def test_td_style_in_js_render(self):
+        """JS createdCell must set white-space:normal on digest_text cells."""
         resp = self._page()
         html = resp.text
-        self.assertIn('white-space:normal', html,
-                      "digest_text td must use white-space:normal")
+        self.assertIn('white-space', html,
+                      "white-space style missing from JS createdCell function")
         self.assertNotIn('white-space:pre-wrap', html,
                          "digest_text td must not use white-space:pre-wrap")
 
-    def test_short_span_truncated_at_100(self):
-        """digest-short span text must be at most 100 chars (not the old 60-char limit).
+    def test_api_returns_digest_text_data(self):
+        """The /api/table_data endpoint must return digest_text values for JS to render."""
+        self._page()  # populate session
+        body = self.s.get_table_data(self.SERVER, self.DATABASE, self.TABLE,
+                                      length="25")
+        self.assertGreater(body.get("recordsTotal", 0), 0,
+                           "stats_mysql_query_digest should have rows")
+        self.assertGreater(len(body.get("data", [])), 0,
+                           "API should return at least one row")
 
-        HTML entities (&gt;, &lt;, &amp;) are decoded before measuring length because
-        Jinja2 truncates the raw string at 100 chars then auto-escapes, which can inflate
-        the HTML representation beyond 100 bytes.
-        """
-        import html as html_mod
+    def test_truncation_at_100_via_substring(self):
+        """JS render function must truncate at 100 chars (substring(0, 100))."""
         resp = self._page()
-        # Extract all digest-short span contents
-        spans = re.findall(r'<span class="digest-short">(.*?)</span>', resp.text)
-        self.assertTrue(len(spans) > 0, "No digest-short spans found on page")
-        for span_text in spans:
-            decoded = html_mod.unescape(span_text)
-            self.assertLessEqual(len(decoded), 100,
-                                 f"digest-short span is longer than 100 chars: {decoded!r}")
+        self.assertIn('substring(0, 100)', resp.text,
+                      "JS render must truncate digest_text at 100 chars")
 
 
 @unittest.skipUnless(HAS_PYMYSQL, "pymysql not installed — skipping pagination tests")
@@ -1597,22 +1608,154 @@ class TestZPagination(unittest.TestCase):
         resp = self._page()
         self.assertEqual(resp.status_code, 200)
 
-    def test_pagination_row_count(self):
-        """Server must return > 100 tbody rows so DataTables activates client-side pagination.
-
-        DataTables pagination is rendered entirely in JavaScript and therefore not present
-        in resp.text.  The correct server-side signal is the number of <tr> elements inside
-        <tbody>: when that count exceeds DataTables' pageLength (100 in base.html), DataTables
-        will render Previous/Next controls after the page loads in a browser.
-        """
+    def test_server_side_mode_active(self):
+        """Page must enable DataTables server-side processing."""
         resp = self._page()
-        tbody_match = re.search(r'<tbody>(.*?)</tbody>', resp.text, re.DOTALL)
-        self.assertIsNotNone(tbody_match,
-                             "No <tbody> found on stats_mysql_query_digest page")
-        data_rows = tbody_match.group(1).count('<tr>')
-        self.assertGreater(data_rows, 100,
-                           f"Expected > 100 rows in tbody so DataTables paginates, "
-                           f"got {data_rows} after seeding {self.QUERY_COUNT} digests")
+        self.assertIn('serverSideMode', resp.text,
+                       "serverSideMode JS variable missing from page")
+        self.assertIn('/api/table_data', resp.text,
+                       "AJAX endpoint URL missing from page JS")
+
+    def test_pagination_via_api(self):
+        """The /api/table_data endpoint must report > 100 total rows and paginate correctly.
+
+        With server-side DataTables the HTML tbody is empty (rows load via AJAX).
+        Verify the API returns the correct total count and a page of the requested size.
+        """
+        self._page()  # populate session
+        body = self.s.get_table_data(self.SERVER, self.DATABASE, self.TABLE,
+                                      length="100")
+        self.assertGreater(body.get("recordsTotal", 0), 100,
+                           f"Expected > 100 total records after seeding {self.QUERY_COUNT} "
+                           f"digests, got {body.get('recordsTotal', 0)}")
+        self.assertEqual(len(body.get("data", [])), 100,
+                         f"Expected exactly 100 rows in first page, "
+                         f"got {len(body.get('data', []))}")
+
+
+class TestServerSidePagination(unittest.TestCase):
+    """Verify /api/table_data returns correct DataTables server-side JSON."""
+
+    SERVER   = SERVER
+    DATABASE = "main"
+    TABLE    = "mysql_servers"
+
+    def setUp(self):
+        self.s = ProxyWebSession()
+        self.s.login()
+        # Load table page to populate session
+        self.s.get(f"/{self.SERVER}/{self.DATABASE}/{self.TABLE}/")
+
+    def _api(self, **overrides):
+        params = {
+            "server": self.SERVER, "database": self.DATABASE,
+            "table": self.TABLE, "draw": "1", "start": "0",
+            "length": "25", "search[value]": "",
+            "order[0][column]": "0", "order[0][dir]": "asc",
+        }
+        params.update(overrides)
+        return self.s.session.get(f"{BASE_URL}/api/table_data",
+                                  params=params, timeout=10)
+
+    def test_response_format(self):
+        """API must return draw, recordsTotal, recordsFiltered, and data keys."""
+        body = self._api().json()
+        for key in ("draw", "recordsTotal", "recordsFiltered", "data"):
+            self.assertIn(key, body, f"Missing key {key!r} in response")
+        self.assertIsInstance(body["data"], list)
+
+    def test_draw_echo(self):
+        """draw parameter must be echoed back."""
+        body = self._api(draw="42").json()
+        self.assertEqual(body["draw"], 42)
+
+    def test_page_size(self):
+        """Returned data length must not exceed requested length."""
+        body = self._api(length="2").json()
+        self.assertLessEqual(len(body["data"]), 2)
+
+    def test_length_capped_at_1000(self):
+        """Requesting length > 1000 must be capped to 1000."""
+        body = self._api(length="99999").json()
+        self.assertLessEqual(len(body["data"]), 1000)
+
+    def test_search_filters(self):
+        """Searching for a known value should reduce recordsFiltered."""
+        full = self._api().json()
+        # Use a non-existent search term — recordsFiltered should be 0 or less than total
+        filtered = self._api(**{"search[value]": "ZZZZNONEXISTENT99999"}).json()
+        self.assertLessEqual(filtered["recordsFiltered"], full["recordsTotal"])
+
+    def test_sort_direction(self):
+        """Sort direction parameter must be respected (asc vs desc)."""
+        asc = self._api(**{"order[0][dir]": "asc"}).json()
+        desc = self._api(**{"order[0][dir]": "desc"}).json()
+        # Both should succeed and return data
+        self.assertEqual(asc["recordsTotal"], desc["recordsTotal"])
+
+    def test_missing_server_returns_error(self):
+        """Missing server parameter should return an error response."""
+        body = self._api(server="").json()
+        self.assertIn("error", body)
+
+    def test_invalid_server_returns_error(self):
+        """A server name not in config must return an error, not crash."""
+        body = self._api(server="nonexistent_server_xyz").json()
+        self.assertIn("error", body)
+        self.assertEqual(body["recordsTotal"], 0)
+
+    def test_missing_table_returns_error(self):
+        """Missing table parameter should return an error response."""
+        body = self._api(table="").json()
+        self.assertIn("error", body)
+
+    def test_invalid_order_dir_defaults_to_asc(self):
+        """Invalid order direction should not crash; server normalises to 'asc'."""
+        body = self._api(**{"order[0][dir]": "DROP TABLE"}).json()
+        self.assertNotIn("error", body)
+        self.assertIsInstance(body["data"], list)
+
+    def test_negative_start_clamped(self):
+        """Negative start offset should be clamped to 0, not error."""
+        body = self._api(start="-5").json()
+        self.assertNotIn("error", body)
+        self.assertIsInstance(body["data"], list)
+
+    def test_zero_length_clamped(self):
+        """Zero length should be clamped to 1, not return empty or error."""
+        body = self._api(length="0").json()
+        self.assertNotIn("error", body)
+        self.assertLessEqual(len(body["data"]), 1)
+
+    def test_second_page_offset(self):
+        """Requesting start > 0 should return a different page of data."""
+        page1 = self._api(start="0", length="2").json()
+        page2 = self._api(start="2", length="2").json()
+        # Both must succeed
+        self.assertIsInstance(page1["data"], list)
+        self.assertIsInstance(page2["data"], list)
+        if page1["recordsTotal"] > 2:
+            self.assertNotEqual(page1["data"], page2["data"],
+                                "Page 1 and page 2 should contain different rows")
+
+    def test_search_known_value(self):
+        """Searching for a value present in the table should return it."""
+        # mysql_servers has known hostgroups; search for hostgroup_id column value
+        full = self._api().json()
+        if full["recordsTotal"] > 0:
+            # Pick a value from the first row to search for
+            first_row = full["data"][0]
+            search_val = str(first_row[0])
+            filtered = self._api(**{"search[value]": search_val}).json()
+            self.assertGreater(filtered["recordsFiltered"], 0,
+                               f"Searching for '{search_val}' should find at least one row")
+
+    def test_non_numeric_draw_returns_error(self):
+        """Non-numeric draw parameter should return gracefully."""
+        resp = self._api(draw="notanumber")
+        body = resp.json()
+        # Should either error cleanly or default — must not 500
+        self.assertIn(resp.status_code, (200, 400))
 
 
 # ---------------------------------------------------------------------------
@@ -2374,8 +2517,10 @@ class TestPgSQLNavigation(unittest.TestCase):
 
     def test_pgsql_users_show_pguser(self):
         """The pguser registered via init must appear in pgsql_users."""
-        resp = self.s.get(f"/{PG_SERVER}/{DATABASE}/pgsql_users/")
-        self.assertIn("pguser", resp.text)
+        self.s.get(f"/{PG_SERVER}/{DATABASE}/pgsql_users/")
+        data = self.s.get_table_data(PG_SERVER, DATABASE, "pgsql_users")
+        flat = str(data["data"])
+        self.assertIn("pguser", flat)
 
     def test_runtime_pgsql_servers_table_view(self):
         """runtime_pgsql_servers should be browsable and show the publisher backend."""
@@ -2520,8 +2665,10 @@ class TestPgSQLUsers(unittest.TestCase):
 
     def test_table_view_shows_pguser(self):
         """The pguser registered by init must appear."""
-        resp = self.s.get(f"/{self.SERVER}/{self.DATABASE}/{self.TABLE}/")
-        self.assertIn("pguser", resp.text)
+        self.s.get(f"/{self.SERVER}/{self.DATABASE}/{self.TABLE}/")
+        data = self.s.get_table_data(self.SERVER, self.DATABASE, self.TABLE)
+        flat = str(data["data"])
+        self.assertIn("pguser", flat)
 
 
 class TestPgSQLLoadSave(unittest.TestCase):

--- a/test/test_proxyweb.py
+++ b/test/test_proxyweb.py
@@ -1039,14 +1039,16 @@ class TestMultiServer(unittest.TestCase):
     def test_mysql_server_has_mysql_backends(self):
         """proxysql_mysql should list mysql2 as its backend."""
         self.s.get(f"/{self.S1}/{self.DB}/mysql_servers/")
-        data = self.s.get_table_data(self.S1, self.DB, "mysql_servers")
+        data = self.s.get_table_data(self.S1, self.DB, "mysql_servers",
+                                      **{"search[value]": "mysql2"})
         flat = str(data["data"])
         self.assertIn("mysql2", flat)
 
     def test_pg_server_has_postgres_backends(self):
         """proxysql_postgres should list postgres backends."""
         self.s.get(f"/{self.S2}/{self.DB}/pgsql_servers/")
-        data = self.s.get_table_data(self.S2, self.DB, "pgsql_servers")
+        data = self.s.get_table_data(self.S2, self.DB, "pgsql_servers",
+                                      **{"search[value]": "postgres"})
         flat = str(data["data"])
         self.assertIn("postgres", flat)
 
@@ -1680,18 +1682,24 @@ class TestServerSidePagination(unittest.TestCase):
         self.assertLessEqual(len(body["data"]), 1000)
 
     def test_search_filters(self):
-        """Searching for a known value should reduce recordsFiltered."""
-        full = self._api().json()
-        # Use a non-existent search term — recordsFiltered should be 0 or less than total
+        """Searching for a nonexistent term must return zero matches."""
         filtered = self._api(**{"search[value]": "ZZZZNONEXISTENT99999"}).json()
-        self.assertLessEqual(filtered["recordsFiltered"], full["recordsTotal"])
+        self.assertEqual(filtered["recordsFiltered"], 0,
+                         "Nonexistent search term should yield 0 filtered records")
+        self.assertEqual(len(filtered["data"]), 0,
+                         "Nonexistent search term should return no rows")
 
     def test_sort_direction(self):
-        """Sort direction parameter must be respected (asc vs desc)."""
-        asc = self._api(**{"order[0][dir]": "asc"}).json()
-        desc = self._api(**{"order[0][dir]": "desc"}).json()
-        # Both should succeed and return data
+        """Sort direction parameter must produce opposite row ordering."""
+        asc = self._api(**{"order[0][dir]": "asc", "order[0][column]": "0"}).json()
+        desc = self._api(**{"order[0][dir]": "desc", "order[0][column]": "0"}).json()
         self.assertEqual(asc["recordsTotal"], desc["recordsTotal"])
+        if len(asc["data"]) > 1 and len(desc["data"]) > 1:
+            # First column values should be in opposite order
+            asc_vals = [row[0] for row in asc["data"]]
+            desc_vals = [row[0] for row in desc["data"]]
+            self.assertEqual(asc_vals, list(reversed(desc_vals)),
+                             "asc and desc should produce reversed row order")
 
     def test_missing_server_returns_error(self):
         """Missing server parameter should return an error response."""
@@ -1739,8 +1747,7 @@ class TestServerSidePagination(unittest.TestCase):
                                 "Page 1 and page 2 should contain different rows")
 
     def test_search_known_value(self):
-        """Searching for a value present in the table should return it."""
-        # mysql_servers has known hostgroups; search for hostgroup_id column value
+        """Searching for a value present in the table should return matching rows."""
         full = self._api().json()
         if full["recordsTotal"] > 0:
             # Pick a value from the first row to search for
@@ -1749,6 +1756,11 @@ class TestServerSidePagination(unittest.TestCase):
             filtered = self._api(**{"search[value]": search_val}).json()
             self.assertGreater(filtered["recordsFiltered"], 0,
                                f"Searching for '{search_val}' should find at least one row")
+            # Verify returned rows actually contain the search value
+            for row in filtered["data"]:
+                row_str = " ".join(str(c) for c in row)
+                self.assertIn(search_val, row_str,
+                              f"Row {row} should contain search term '{search_val}'")
 
     def test_non_numeric_draw_returns_error(self):
         """Non-numeric draw parameter should return gracefully."""
@@ -2518,7 +2530,8 @@ class TestPgSQLNavigation(unittest.TestCase):
     def test_pgsql_users_show_pguser(self):
         """The pguser registered via init must appear in pgsql_users."""
         self.s.get(f"/{PG_SERVER}/{DATABASE}/pgsql_users/")
-        data = self.s.get_table_data(PG_SERVER, DATABASE, "pgsql_users")
+        data = self.s.get_table_data(PG_SERVER, DATABASE, "pgsql_users",
+                                      **{"search[value]": "pguser"})
         flat = str(data["data"])
         self.assertIn("pguser", flat)
 
@@ -2666,7 +2679,8 @@ class TestPgSQLUsers(unittest.TestCase):
     def test_table_view_shows_pguser(self):
         """The pguser registered by init must appear."""
         self.s.get(f"/{self.SERVER}/{self.DATABASE}/{self.TABLE}/")
-        data = self.s.get_table_data(self.SERVER, self.DATABASE, self.TABLE)
+        data = self.s.get_table_data(self.SERVER, self.DATABASE, self.TABLE,
+                                      **{"search[value]": "pguser"})
         flat = str(data["data"])
         self.assertIn("pguser", flat)
 


### PR DESCRIPTION
Tables like stats_mysql_query_digest and history_mysql_query_digest can have thousands of rows. Previously all rows were loaded into memory at once, which could trigger Linux OOM killer. Now uses DataTables server-side processing with LIMIT/OFFSET — only one page of rows is ever in memory at a time.

- add get_table_metadata() and get_table_content_paginated() to mdb.py
- add /api/table_data endpoint with input validation and server check
- switch show_table_info.html to server-side mode (empty tbody, AJAX)
- JS digest_text column rendering with truncation and expand/collapse
- drawCallback re-attaches inline editing after each page draw
- fix error handler in /api/table_data for non-numeric draw parameter
- add 9 new TestServerSidePagination tests covering paging, search, sort, input validation, and error handling
- update test/README.md with current stack layout and test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table views now use server-side pagination with an authenticated paginated data API; client-side table rendering adjusted to work with server-side mode.

* **Documentation**
  * README and guidance updated to describe server-side pagination and revised table-browser behavior.

* **Tests**
  * Integration tests updated to use the paginated API and added server-side pagination test suite and related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->