### PR TITLE
fixing table editing issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,3 +187,4 @@ Rules:
 | persistent per-server query history: isolation between servers, dropdown shows last 10, full page shows all, clear per server | `TestQueryHistory` |
 | ProxySQL 3.x admin rejects `SET @@session.autocommit` → `db_connect()` crashes on every page load; removed unnecessary autocommit setter | `TestProxySQL3Autocommit` |
 | `get_table_metadata` compared `row_count` (str from ProxySQL `COUNT(*)`) against int threshold, raising TypeError and breaking DataTables with empty grid / ajax error | `TestSmallTableClientSideMode` |
+| `get_primary_key_columns` only parsed block-form `PRIMARY KEY (...)` → for ProxySQL's SQLite-style inline `col TYPE PRIMARY KEY` (e.g. `mysql_query_rules.rule_id`) the WHERE clause silently fell back to all columns, so edits returned `success=True` but matched zero rows and reverted on refresh | `TestInlinePrimaryKeyUpdate` |

--- a/mdb.py
+++ b/mdb.py
@@ -1366,12 +1366,61 @@ def get_table_schema(db, server, database, table_name):
     return result
 
 
+def _split_top_level_commas(s):
+    """Split *s* on commas that are at parenthesis depth zero."""
+    parts = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(s):
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth = max(depth - 1, 0)
+        elif ch == ',' and depth == 0:
+            parts.append(s[start:i])
+            start = i + 1
+    parts.append(s[start:])
+    return parts
+
+
+def _parse_inline_primary_keys(create_table_sql):
+    """Extract PK columns declared inline as ``colname TYPE ... PRIMARY KEY``.
+
+    ProxySQL (SQLite-backed) uses this form for many admin tables
+    (``mysql_query_rules``, ``global_variables``, ``scheduler``, etc.)
+    where the classic ``PRIMARY KEY (col, ...)`` trailing clause is absent.
+    """
+    first = create_table_sql.find('(')
+    last = create_table_sql.rfind(')')
+    if first == -1 or last <= first:
+        return []
+    body = create_table_sql[first + 1:last]
+
+    reserved = {'PRIMARY', 'UNIQUE', 'KEY', 'CHECK',
+                'CONSTRAINT', 'FOREIGN', 'INDEX'}
+    pk_cols = []
+    for defn in _split_top_level_commas(body):
+        defn = defn.strip()
+        if not defn:
+            continue
+        if not re.search(r'\bPRIMARY\s+KEY\b(?!\s*\()', defn, re.IGNORECASE):
+            continue
+        m = re.match(r'[`"\[]?([A-Za-z_][\w$]*)[`"\]]?\b', defn)
+        if not m:
+            continue
+        first_ident = m.group(1)
+        if first_ident.upper() in reserved:
+            continue
+        pk_cols.append(first_ident)
+    return pk_cols
+
+
 def get_primary_key_columns(db, server, database, table_name):
     """
     Return the primary key column names defined for the specified table.
-    
+
     Parses the table's CREATE TABLE SQL and extracts the PRIMARY KEY column list.
-    
+
     Returns:
         list: Primary key column names in definition order. Returns an empty list if the table has no primary key or if the primary key cannot be determined.
     """
@@ -1394,20 +1443,24 @@ def get_primary_key_columns(db, server, database, table_name):
         else:
             create_table_sql = create_table_result[1]
 
-        # Find PRIMARY KEY definition
-        # Pattern: PRIMARY KEY (column1, column2, ...)
+        # Block form: PRIMARY KEY (column1, column2, ...)
         pk_pattern = r'PRIMARY\s+KEY\s*\(([^)]+)\)'
         match = re.search(pk_pattern, create_table_sql, re.IGNORECASE)
-
         if match:
-            pk_columns_str = match.group(1)
-            # Split by comma and clean up column names
-            pk_columns = [col.strip().strip('`"[]') for col in pk_columns_str.split(',')]
+            pk_columns = [col.strip().strip('`"[]')
+                          for col in match.group(1).split(',')]
             logging.debug(f"Primary key columns for {table_name}: {pk_columns}")
             return pk_columns
-        else:
-            logging.warning(f"No primary key found for table {table_name}")
-            return []
+
+        # Inline form: `col TYPE ... PRIMARY KEY` — common in ProxySQL's
+        # SQLite-style admin schemas, and missed by the block-form regex above.
+        inline_pk = _parse_inline_primary_keys(create_table_sql)
+        if inline_pk:
+            logging.debug(f"Primary key columns for {table_name}: {inline_pk}")
+            return inline_pk
+
+        logging.warning(f"No primary key found for table {table_name}")
+        return []
 
     except Exception as e:
         logging.error(f"Error extracting primary key for {table_name}: {e}")

--- a/test/test_proxyweb.py
+++ b/test/test_proxyweb.py
@@ -2168,6 +2168,113 @@ class _ColoredRunner:
         return result
 
 
+class TestInlinePrimaryKeyUpdate(unittest.TestCase):
+    """Updates must persist for ProxySQL tables whose PK is declared inline.
+
+    Regression: ``get_primary_key_columns`` only parsed the block form
+    ``PRIMARY KEY (col, ...)`` and returned ``[]`` for ProxySQL's SQLite-style
+    inline PKs (e.g. ``rule_id INTEGER PRIMARY KEY AUTOINCREMENT`` on
+    ``mysql_query_rules``). ``update_row`` then fell back to using *every*
+    column sent by the browser as the WHERE clause. Because the browser
+    captures cell text — NULL rendered by Jinja as the literal ``"None"`` —
+    the WHERE matched zero rows. ``execute_change`` reported no SQL error,
+    so the API returned ``success=True`` but ProxySQL was never modified,
+    and the edit vanished on the next page load.
+    """
+
+    SERVER   = SERVER
+    DATABASE = "main"
+    TABLE    = "mysql_query_rules"
+    TEST_RULE_ID = 981
+
+    def setUp(self):
+        self.s = ProxyWebSession()
+        self.s.login()
+        self.s.get(f"/{self.SERVER}/{self.DATABASE}/{self.TABLE}/")
+        # Clean up any stragglers from prior failed runs
+        self._delete(ignore_errors=True)
+
+    def tearDown(self):
+        self._delete(ignore_errors=True)
+
+    def _delete(self, ignore_errors=False):
+        try:
+            resp = self.s.post_json("/api/delete_row", {
+                "server":   self.SERVER,
+                "database": self.DATABASE,
+                "table":    self.TABLE,
+                "pkValues": {"rule_id": str(self.TEST_RULE_ID)},
+            })
+            return resp.json()
+        except Exception:
+            if not ignore_errors:
+                raise
+
+    def _fetch_row(self):
+        """Return the test row as {col: value}, or None if not present."""
+        body = self.s.get_table_data(
+            self.SERVER, self.DATABASE, self.TABLE,
+            **{"search[value]": str(self.TEST_RULE_ID), "length": "100"},
+        )
+        cols = body["column_names"]
+        rule_id_idx = cols.index("rule_id")
+        for row in body["data"]:
+            if str(row[rule_id_idx]) == str(self.TEST_RULE_ID):
+                return dict(zip(cols, row))
+        return None
+
+    def test_update_persists_with_browser_style_pkvalues(self):
+        """Simulate the browser: send every column as ``pkValues``, including
+        NULL columns rendered as the literal string ``"None"``. With a correct
+        PK lookup the backend must filter the WHERE to ``rule_id`` only and
+        the update must be visible on the next read."""
+
+        insert = self.s.post_json("/api/insert_row", {
+            "server":      self.SERVER,
+            "database":    self.DATABASE,
+            "table":       self.TABLE,
+            "columnNames": ["rule_id", "active", "match_pattern", "apply"],
+            "data": {
+                "rule_id":       str(self.TEST_RULE_ID),
+                "active":        "1",
+                "match_pattern": "original",
+                "apply":         "1",
+            },
+        }).json()
+        self.assertTrue(insert.get("success"), insert.get("error"))
+
+        row = self._fetch_row()
+        self.assertIsNotNone(row, "inserted test row not readable back")
+        self.assertEqual(row["match_pattern"], "original")
+
+        # Build pkValues the way base.html's enableInlineEditing() does:
+        # every column in the row, with None rendered by Jinja as "None".
+        pk_values = {
+            col: ("None" if val is None else str(val))
+            for col, val in row.items()
+        }
+        column_names = list(row.keys())
+
+        upd = self.s.post_json("/api/update_row", {
+            "server":      self.SERVER,
+            "database":    self.DATABASE,
+            "table":       self.TABLE,
+            "pkValues":    pk_values,
+            "columnNames": column_names,
+            "data":        {"match_pattern": "updated"},
+        }).json()
+        self.assertTrue(upd.get("success"), upd.get("error"))
+
+        refreshed = self._fetch_row()
+        self.assertIsNotNone(refreshed)
+        self.assertEqual(
+            refreshed["match_pattern"], "updated",
+            "UPDATE returned success=True but the change did not persist — "
+            "WHERE clause likely included non-PK columns with 'None' literals "
+            "(inline PRIMARY KEY not detected in get_primary_key_columns)",
+        )
+
+
 class TestQueryHistory(unittest.TestCase):
     """Verify per-server persistent query history across two servers.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed primary key detection for ProxySQL tables using SQLite-style inline `PRIMARY KEY` syntax. Previously, updates would report success but fail to persist data, causing rows to revert on refresh.

* **Tests**
  * Added integration test coverage for update operations on tables with inline `PRIMARY KEY` declarations to ensure data persistence and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->