### PR TITLE
ui(table): add per-row Copy SQL button on disk/memory/runtime tables

### DIFF
--- a/misc/proxyweb.org/index.html
+++ b/misc/proxyweb.org/index.html
@@ -710,6 +710,12 @@
         <h3>Query history</h3>
         <p>Persistent per-server query history. Recall recent queries from a dropdown, browse the full history page, and clear per server.</p>
       </div>
+
+      <div class="feature-card fade-up">
+        <div class="feature-label">Operations</div>
+        <h3>Copy row as SQL</h3>
+        <p>One click copies any row as the INSERT (or SET, for global variables) that would recreate it. Works on Disk, Memory, and Runtime tables &mdash; runtime_ rows copy as statements pasteable against the Memory table.</p>
+      </div>
     </div>
   </section>
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -453,9 +453,9 @@ footer {
     left: 0;
     background-color: #e2e8f0 !important;
     z-index: 11;
-    width: 100px;
-    min-width: 100px;
-    max-width: 100px;
+    width: 156px;
+    min-width: 156px;
+    max-width: 156px;
     border-right: 1px solid #000000 !important;
 }
 
@@ -474,9 +474,9 @@ footer {
     background-color: white !important;
     text-align: left;
     padding: 0.5rem 0.75rem;
-    width: 100px;
-    min-width: 100px;
-    max-width: 100px;
+    width: 156px;
+    min-width: 156px;
+    max-width: 156px;
     z-index: 10;
     border-right: 1px solid #000000 !important;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -329,26 +329,21 @@
             const table = document.getElementById('proxywebtable');
             if (!table) return;
 
-            // Check if table is editable based on our new restrictions
-            if (!isTableEditable()) {
-                console.log('[DEBUG] Table is not editable, returning early');
-                return;
-            }
-
-            console.log('[DEBUG] Table is editable, continuing...');
+            const tableIsEditable = isTableEditable();
+            console.log('[DEBUG] tableIsEditable:', tableIsEditable);
 
             // Check if table has a variable_name column
             const headerCells = table.querySelectorAll('thead th');
             const hasVariableNameColumn = Array.from(headerCells).some(th => th.textContent.trim() === 'variable_name');
             console.log('[DEBUG] hasVariableNameColumn:', hasVariableNameColumn);
 
-            // Add header cell for actions column at the beginning
+            // Add header cell for actions column at the beginning (always — copy button lives here too)
             const thead = table.querySelector('thead tr');
             if (thead && !thead.querySelector('th.actions-header')) {
                 const actionsHeader = document.createElement('th');
                 actionsHeader.className = 'actions-header';
-                actionsHeader.style.width = '100px';
-                actionsHeader.style.minWidth = '100px';
+                actionsHeader.style.width = '156px';
+                actionsHeader.style.minWidth = '156px';
                 actionsHeader.textContent = '';
                 thead.insertBefore(actionsHeader, thead.firstChild);
             }
@@ -440,12 +435,14 @@
                     rowData.push(cell.textContent.trim());
                 });
 
-                // Create edit controls cell
-                const controlsCell = document.createElement('td');
-                controlsCell.className = 'edit-controls';
-                controlsCell.style.whiteSpace = 'nowrap';
-                controlsCell.innerHTML = `
-                    <div class="action-buttons">
+                const generatedSql = buildRowSql(columnNames, rowData, tableName);
+                const copyButtonHtml = `
+                        <button type="button" class="btn btn-icon btn-icon-secondary copy-btn" onclick="copyRowSql(this)"
+                                data-sql="${escapeHtmlAttr(generatedSql)}"
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="Copy SQL" aria-label="Copy row SQL">
+                            <i class="fas fa-copy"></i>
+                        </button>`;
+                const editDeleteHtml = tableIsEditable ? `
                         <button type="button" class="btn btn-icon edit-btn" onclick="editRow(this)"
                                 data-bs-toggle="tooltip" data-bs-placement="top" title="Edit row" aria-label="Edit row">
                             <i class="fas fa-edit"></i>
@@ -453,7 +450,13 @@
                         <button type="button" class="btn btn-icon delete-btn" onclick="deleteRow(this)"
                                 data-bs-toggle="tooltip" data-bs-placement="top" title="Delete row" aria-label="Delete row">
                             <i class="fas fa-trash"></i>
-                        </button>
+                        </button>` : '';
+
+                const controlsCell = document.createElement('td');
+                controlsCell.className = 'edit-controls';
+                controlsCell.style.whiteSpace = 'nowrap';
+                controlsCell.innerHTML = `
+                    <div class="action-buttons">${editDeleteHtml}${copyButtonHtml}
                     </div>
                 `;
                 row.insertBefore(controlsCell, row.firstChild);
@@ -463,10 +466,12 @@
                 row.dataset.columnNames = JSON.stringify(columnNames);
             });
 
-            // Add hidden row for new row insertion
-            const tbody = table.querySelector('tbody');
-            if (tbody && !tbody.querySelector('.new-row-template')) {
-                createNewRowTemplate(table);
+            // Add hidden row for new row insertion (editable tables only)
+            if (tableIsEditable) {
+                const tbody = table.querySelector('tbody');
+                if (tbody && !tbody.querySelector('.new-row-template')) {
+                    createNewRowTemplate(table);
+                }
             }
 
             // Apply floating button behavior to rows that need horizontal scrolling
@@ -496,6 +501,91 @@
                 } else {
                     row.classList.remove('has-overflow');
                 }
+            });
+        }
+
+        // Escape a string for safe inclusion in a double-quoted HTML attribute.
+        function escapeHtmlAttr(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+        }
+
+        // Build the SQL that would recreate the given row.
+        // Regular tables get an INSERT with single-quoted values; global_variables
+        // tables (memory or runtime) get a SET statement with a double-quoted value.
+        // For runtime_* source tables the target table name has `runtime_` stripped
+        // so the copied SQL is pasteable against ProxySQL (runtime_ is read-only).
+        function buildRowSql(columnNames, rowData, sourceTableName) {
+            const targetTable = sourceTableName.startsWith('runtime_')
+                ? sourceTableName.slice('runtime_'.length)
+                : sourceTableName;
+
+            if (targetTable === 'global_variables') {
+                const nameIdx = columnNames.indexOf('variable_name');
+                const valueIdx = columnNames.indexOf('variable_value');
+                if (nameIdx === -1 || valueIdx === -1) return '';
+                const name = String(rowData[nameIdx] ?? '');
+                const value = String(rowData[valueIdx] ?? '').replace(/"/g, '""');
+                return `SET ${name}="${value}";`;
+            }
+
+            // Skip columns whose DOM value is NULL (rendered as the literal
+            // string "None" by the Jinja template). Mirrors insert_row() in
+            // mdb.py which omits None values so DEFAULTs apply.
+            const keptCols = [];
+            const keptVals = [];
+            for (let i = 0; i < columnNames.length; i++) {
+                const raw = rowData[i];
+                if (raw === null || raw === undefined || raw === 'None') continue;
+                keptCols.push(columnNames[i]);
+                keptVals.push("'" + String(raw).replace(/'/g, "''") + "'");
+            }
+            return `INSERT INTO ${targetTable}(${keptCols.join(',')}) VALUES (${keptVals.join(',')});`;
+        }
+
+        // Write `text` to the clipboard, falling back to a hidden textarea +
+        // document.execCommand('copy') when navigator.clipboard is unavailable
+        // (plain HTTP origins — ProxyWeb is commonly served on a LAN IP).
+        function writeToClipboard(text) {
+            if (navigator.clipboard && window.isSecureContext) {
+                return navigator.clipboard.writeText(text);
+            }
+            return new Promise((resolve, reject) => {
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.setAttribute('readonly', '');
+                ta.style.position = 'fixed';
+                ta.style.top = '-9999px';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                ta.setSelectionRange(0, text.length);
+                let ok = false;
+                try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+                document.body.removeChild(ta);
+                ok ? resolve() : reject(new Error('execCommand copy failed'));
+            });
+        }
+
+        // Copy the SQL stored on a copy button to the clipboard and flash a
+        // check-mark icon for ~1.5s. Mirrors templates/query_history.html.
+        function copyRowSql(button) {
+            const sql = button.getAttribute('data-sql') || '';
+            if (!sql) return;
+            writeToClipboard(sql).then(() => {
+                const icon = button.querySelector('i');
+                if (!icon) return;
+                icon.classList.replace('fa-copy', 'fa-check');
+                button.classList.replace('btn-icon-secondary', 'btn-icon-success');
+                setTimeout(() => {
+                    icon.classList.replace('fa-check', 'fa-copy');
+                    button.classList.replace('btn-icon-success', 'btn-icon-secondary');
+                }, 1500);
+            }).catch(err => {
+                console.error('Clipboard write failed:', err);
             });
         }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -435,30 +435,10 @@
                     rowData.push(cell.textContent.trim());
                 });
 
-                const generatedSql = buildRowSql(columnNames, rowData, tableName);
-                const copyButtonHtml = `
-                        <button type="button" class="btn btn-icon btn-icon-secondary copy-btn" onclick="copyRowSql(this)"
-                                data-sql="${escapeHtmlAttr(generatedSql)}"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="Copy SQL" aria-label="Copy row SQL">
-                            <i class="fas fa-copy"></i>
-                        </button>`;
-                const editDeleteHtml = tableIsEditable ? `
-                        <button type="button" class="btn btn-icon edit-btn" onclick="editRow(this)"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="Edit row" aria-label="Edit row">
-                            <i class="fas fa-edit"></i>
-                        </button>
-                        <button type="button" class="btn btn-icon delete-btn" onclick="deleteRow(this)"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="Delete row" aria-label="Delete row">
-                            <i class="fas fa-trash"></i>
-                        </button>` : '';
-
                 const controlsCell = document.createElement('td');
                 controlsCell.className = 'edit-controls';
                 controlsCell.style.whiteSpace = 'nowrap';
-                controlsCell.innerHTML = `
-                    <div class="action-buttons">${editDeleteHtml}${copyButtonHtml}
-                    </div>
-                `;
+                controlsCell.innerHTML = buildControlsHtml(columnNames, rowData, tableIsEditable);
                 row.insertBefore(controlsCell, row.firstChild);
 
                 // Store row data as data attributes
@@ -502,6 +482,32 @@
                     row.classList.remove('has-overflow');
                 }
             });
+        }
+
+        // Build the action-buttons markup used by both the initial row render
+        // (enableInlineEditing) and the post-edit restore (restoreEditControls).
+        // Editable rows get Edit+Delete+Copy; read-only rows get Copy only.
+        function buildControlsHtml(columnNames, rowData, tableIsEditable) {
+            const generatedSql = buildRowSql(columnNames, rowData, tableName);
+            const copyButtonHtml = `
+                        <button type="button" class="btn btn-icon btn-icon-secondary copy-btn" onclick="copyRowSql(this)"
+                                data-sql="${escapeHtmlAttr(generatedSql)}"
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="Copy SQL" aria-label="Copy row SQL">
+                            <i class="fas fa-copy"></i>
+                        </button>`;
+            const editDeleteHtml = tableIsEditable ? `
+                        <button type="button" class="btn btn-icon edit-btn" onclick="editRow(this)"
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="Edit row" aria-label="Edit row">
+                            <i class="fas fa-edit"></i>
+                        </button>
+                        <button type="button" class="btn btn-icon delete-btn" onclick="deleteRow(this)"
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="Delete row" aria-label="Delete row">
+                            <i class="fas fa-trash"></i>
+                        </button>` : '';
+            return `
+                    <div class="action-buttons">${editDeleteHtml}${copyButtonHtml}
+                    </div>
+                `;
         }
 
         // Escape a string for safe inclusion in a double-quoted HTML attribute.
@@ -930,18 +936,19 @@
 
         function restoreEditControls(row) {
             const controlsCell = row.querySelector('.edit-controls');
-            controlsCell.innerHTML = `
-                <div class="action-buttons">
-                    <button type="button" class="btn btn-icon edit-btn" onclick="editRow(this)"
-                            data-bs-toggle="tooltip" data-bs-placement="top" title="Edit row" aria-label="Edit row">
-                        <i class="fas fa-edit"></i>
-                    </button>
-                    <button type="button" class="btn btn-icon delete-btn" onclick="deleteRow(this)"
-                            data-bs-toggle="tooltip" data-bs-placement="top" title="Delete row" aria-label="Delete row">
-                        <i class="fas fa-trash"></i>
-                    </button>
-                </div>
-            `;
+            // Re-read values from the live cells so the rebuilt Copy button
+            // reflects edits just saved (saveRow writes back via textContent)
+            // or the originals restored by cancelEdit.
+            const columnNames = JSON.parse(row.dataset.columnNames || '[]');
+            const table = row.closest('table');
+            const headerCells = Array.from(table.querySelectorAll('thead th'))
+                .filter(th => !th.classList.contains('actions-header'));
+            const dataCells = row.querySelectorAll('td:not(.edit-controls)');
+            const rowData = headerCells.map((_th, i) => {
+                const cell = dataCells[i];
+                return cell ? cell.textContent.trim() : '';
+            });
+            controlsCell.innerHTML = buildControlsHtml(columnNames, rowData, isTableEditable());
             document.querySelectorAll('.edit-btn').forEach(btn => btn.disabled = false);
 
             // Re-initialize tooltips for the restored buttons

--- a/test/cases/test_copy_row_button.py
+++ b/test/cases/test_copy_row_button.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Per-row 'Copy SQL' button ships for disk/memory/runtime tables.
+
+Regression guard for the copy-button feature: every row in every ProxySQL
+table view should render a clipboard button whose SQL is generated
+client-side from the row's column names and values. Requirements:
+
+- The page must ship the ``buildRowSql`` and ``copyRowSql`` JS helpers.
+- The ``enableInlineEditing`` row loop must include ``copy-btn`` markup so
+  the button is appended to every valid data row.
+- The template-exposed globals (``tableName``, ``tableColumnNames``) must
+  carry the source table name verbatim (including the ``runtime_`` prefix)
+  because the JS helper is the thing that strips ``runtime_`` when
+  building the INSERT/SET statement.
+- Readonly users must also receive the JS helpers (they need the button
+  too) and must be able to load runtime_* pages without a 403.
+
+The HTML-level assertions stop at 'the JS is shipped and the inputs are
+correct'; actually running ``buildRowSql`` requires a JS engine and is
+outside this suite's scope. A reimplementation of ``buildRowSql`` in
+Python (``_py_build_row_sql`` below) verifies the expected output format
+for all three branches the JS covers.
+"""
+
+import re
+import unittest
+
+from testlib import (
+    ProxyWebSession, BASE_URL, USERNAME, PASSWORD,
+    SERVER, DATABASE,
+)
+
+
+def _py_build_row_sql(column_names, row_data, source_table):
+    """Mirror of the JS buildRowSql() in templates/base.html.
+
+    Keep this in sync with that JS function so the test catches divergence
+    if someone edits one without the other.
+    """
+    target = (source_table[len("runtime_"):]
+              if source_table.startswith("runtime_") else source_table)
+
+    if target == "global_variables":
+        name_idx = column_names.index("variable_name")
+        value_idx = column_names.index("variable_value")
+        name = str(row_data[name_idx])
+        value = str(row_data[value_idx]).replace('"', '""')
+        return f'SET {name}="{value}";'
+
+    kept_cols = []
+    kept_vals = []
+    for col, val in zip(column_names, row_data):
+        if val is None or val == "None":
+            continue
+        kept_cols.append(col)
+        kept_vals.append("'" + str(val).replace("'", "''") + "'")
+    return f"INSERT INTO {target}({','.join(kept_cols)}) VALUES ({','.join(kept_vals)});"
+
+
+class TestCopyRowSqlGenerator(unittest.TestCase):
+    """Pure-logic checks for the SQL format the JS helper must produce."""
+
+    def test_insert_format_memory_table(self):
+        self.assertEqual(
+            _py_build_row_sql(
+                ["hostgroup_id", "hostname", "port"],
+                [1, "10.0.0.1", 3306],
+                "mysql_servers",
+            ),
+            "INSERT INTO mysql_servers(hostgroup_id,hostname,port) "
+            "VALUES ('1','10.0.0.1','3306');",
+        )
+
+    def test_insert_format_strips_runtime_prefix(self):
+        """runtime_mysql_servers rows must copy as INSERT INTO mysql_servers."""
+        sql = _py_build_row_sql(
+            ["hostgroup_id", "hostname", "port"],
+            [2, "db-reader", 3306],
+            "runtime_mysql_servers",
+        )
+        self.assertTrue(sql.startswith("INSERT INTO mysql_servers("), sql)
+        self.assertNotIn("runtime_", sql)
+
+    def test_insert_omits_columns_with_none_value(self):
+        """Columns whose DOM value is the literal 'None' (i.e. NULL) are
+        dropped from both the column list and the VALUES list, so ProxySQL
+        applies each column's DEFAULT.
+        """
+        sql = _py_build_row_sql(
+            ["rule_id", "active", "username", "match_pattern", "apply"],
+            ["1", "1", "None", "^SELECT.*FOR UPDATE", "1"],
+            "mysql_query_rules",
+        )
+        self.assertEqual(
+            sql,
+            "INSERT INTO mysql_query_rules(rule_id,active,match_pattern,apply) "
+            "VALUES ('1','1','^SELECT.*FOR UPDATE','1');",
+        )
+        self.assertNotIn("username", sql)
+        self.assertNotIn("'None'", sql)
+
+    def test_insert_escapes_single_quote(self):
+        sql = _py_build_row_sql(
+            ["comment"], ["O'Brien"], "mysql_servers",
+        )
+        self.assertIn("'O''Brien'", sql)
+
+    def test_global_variables_uses_set_with_double_quoted_value(self):
+        self.assertEqual(
+            _py_build_row_sql(
+                ["variable_name", "variable_value"],
+                ["admin-refresh_interval", "1700"],
+                "global_variables",
+            ),
+            'SET admin-refresh_interval="1700";',
+        )
+
+    def test_runtime_global_variables_uses_set(self):
+        sql = _py_build_row_sql(
+            ["variable_name", "variable_value"],
+            ["mysql-threads", "4"],
+            "runtime_global_variables",
+        )
+        self.assertEqual(sql, 'SET mysql-threads="4";')
+
+    def test_global_variables_escapes_double_quote(self):
+        sql = _py_build_row_sql(
+            ["variable_name", "variable_value"],
+            ["mysql-default_charset", 'ut"f8'],
+            "global_variables",
+        )
+        self.assertIn('"ut""f8"', sql)
+
+
+class TestCopyRowButtonShippedToAllTables(unittest.TestCase):
+    """Every table page must ship the JS helpers and the copy-btn template."""
+
+    # JS fingerprints. Keep these tight — they should only match the
+    # feature this test guards, so any rename breaks the test loudly.
+    JS_BUILD_FN   = re.compile(r"function\s+buildRowSql\s*\(")
+    JS_COPY_FN    = re.compile(r"function\s+copyRowSql\s*\(")
+    COPY_BTN_HTML = "copy-btn"
+    COPY_SQL_ATTR = "copyRowSql(this)"
+
+    PAGES = [
+        (DATABASE, "mysql_servers"),
+        (DATABASE, "runtime_mysql_servers"),
+        (DATABASE, "global_variables"),
+        (DATABASE, "runtime_global_variables"),
+        ("disk",   "mysql_servers"),
+    ]
+
+    def setUp(self):
+        self.pw = ProxyWebSession()
+        self.pw.login(USERNAME, PASSWORD)
+
+    def _assert_copy_machinery(self, html, where):
+        self.assertRegex(html, self.JS_BUILD_FN,
+                         f"{where}: buildRowSql JS helper missing")
+        self.assertRegex(html, self.JS_COPY_FN,
+                         f"{where}: copyRowSql JS helper missing")
+        self.assertIn(self.COPY_BTN_HTML, html,
+                      f"{where}: copy-btn class string missing from template")
+        self.assertIn(self.COPY_SQL_ATTR, html,
+                      f"{where}: copyRowSql(this) wiring missing from template")
+
+    def _assert_table_name_global(self, html, expected, where):
+        m = re.search(r"var\s+tableName\s*=\s*(\S+?);", html)
+        self.assertIsNotNone(m, f"{where}: tableName global not found")
+        self.assertEqual(m.group(1).strip('"'), expected,
+                         f"{where}: tableName global should be {expected!r}")
+
+    def test_copy_helpers_present_on_every_table_view(self):
+        for database, table in self.PAGES:
+            with self.subTest(database=database, table=table):
+                resp = self.pw.get(f"/{SERVER}/{database}/{table}/")
+                self.assertEqual(resp.status_code, 200)
+                self._assert_copy_machinery(resp.text, f"{database}/{table}")
+                self._assert_table_name_global(
+                    resp.text, table, f"{database}/{table}")
+
+
+class TestCopyRowButtonAvailableToReadonlyUser(unittest.TestCase):
+    """Readonly users must receive the copy-button JS and see runtime tables."""
+
+    RO_USER = "readonly"
+    RO_PASS = "readonly42"
+
+    def setUp(self):
+        self.pw = ProxyWebSession()
+        self.pw.login(self.RO_USER, self.RO_PASS)
+
+    def test_memory_table_ships_copy_helpers(self):
+        resp = self.pw.get(f"/{SERVER}/{DATABASE}/mysql_servers/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(resp.text, r"function\s+buildRowSql\s*\(")
+        self.assertIn("copyRowSql(this)", resp.text)
+
+    def test_runtime_table_accessible_and_ships_copy_helpers(self):
+        resp = self.pw.get(f"/{SERVER}/{DATABASE}/runtime_mysql_servers/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(resp.text, r"function\s+buildRowSql\s*\(")
+        self.assertIn("copyRowSql(this)", resp.text)
+
+    def test_global_variables_ships_copy_helpers(self):
+        resp = self.pw.get(f"/{SERVER}/{DATABASE}/global_variables/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertRegex(resp.text, r"function\s+buildRowSql\s*\(")
+        self.assertIn("copyRowSql(this)", resp.text)
+
+
+if __name__ == "__main__":
+    import os, sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    unittest.main()


### PR DESCRIPTION
Every row now shows a clipboard button that copies SQL reproducing the row. Editable tables get Edit + Delete + Copy; read-only (runtime_*) tables get Copy only. Regular tables emit INSERT INTO <table>(...) VALUES (...); with single-quoted values and '' escaping; global_variables / runtime_global_variables emit SET <variable_name>="<variable_value>"; with double-quoted value. Runtime rows strip the runtime_ prefix from the target table so the SQL is pasteable against ProxySQL admin, and columns whose value is NULL (rendered as "None") are omitted from the INSERT so DEFAULTs apply.

Uses navigator.clipboard when available and falls back to a hidden textarea + execCommand('copy') on plain-HTTP origins. Sticky actions column widened from 100px to 156px to fit the third button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-row "Copy SQL" button that generates properly formatted SQL statements with automatic escaping for special characters. Supports all table types and is accessible to read-only users.
  * Increased actions column width for better usability.

* **Tests**
  * Added comprehensive test coverage for copy SQL functionality, including SQL formatting, escaping validation, and authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->